### PR TITLE
User properties can now be disabled by setting the "update_user" to "…

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Given the ID of the SAML plugin is "saml":
 - Implements almost everything from python3-saml, this includes SP signing of the AuthnRequest and metadata
 - Create a plone session and/or restapi token
 - Enable/Disable the creation of a plone user
+- Enable/Disable updating user properties (after creation)
 - Automatically updates user data (hardcoded, currently limited to email and fullname)
 - Enable/Disable the validation of authn requests (Uses temporarly a `__saml` cookie)
 - Prevent Redirect attacks, by validating the RelayState parameter and a and an "allowed" list of domains, where we can redirect to

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-1.2.1 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BugFix: Fix updating user properties when user already exists. [mathias.leimgruber]
+- Feature: Updating user properties can now be disabled by setting the "update_user" flag to "False" in the plugin settings. [mathias.leimgruber]
 
 
 1.2.0 (2025-05-19)


### PR DESCRIPTION
…False" in the plugin settings

This included a fix to enable it by default.

Closes #15 